### PR TITLE
Fix README execution order issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ make up
 
 ホストOSのターミナルから、コンテナ内部のコマンドを意識せず、直接 `make` コマンドを実行します。
 
+**Windows PowerShellの場合:**
+```powershell
+# 日本語の文字化けを防ぐため、最初に実行してください
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+```
+
 ---
 
 ## 📊 データパイプライン
@@ -62,6 +68,9 @@ make up
 ```bash
 # 全ティッカーの株価データを取得 (Yahoo Finance)
 make fetch
+
+# Windowsの場合、必要に応じてデータディレクトリを作成
+mkdir data\processed -Force
 ```
 
 **データ保存先:** `data/raw/{ticker}.parquet`
@@ -94,13 +103,15 @@ make full-pipeline
 - Embargo Window: 3サンプル
 - **生成Folds:** C(10,2) = **45 folds/ticker**
 
+**⚠️ 注意:** `make chart` を実行する前に、必ず `make full-pipeline` を実行してください。
+
 ---
 
 ### 3. データの可視化 (CPCV分割 + ラベリング結果)
 
 ```bash
 # 特定ティッカーのインタラクティブチャート生成
-make chart ticker=TSLA
+make chart ticker=AAPL
 ```
 
 **出力先:** `data/charts/{ticker}_cpcv_chart.html`
@@ -144,7 +155,7 @@ make generate-experiments
 
 ```bash
 # 特定ティッカー
-make label ticker=TSLA
+make label ticker=AAPL
 
 # 全ティッカー
 make label-all
@@ -163,7 +174,7 @@ make label-all
 
 ```bash
 # 特定ティッカー
-make split ticker=TSLA
+make split ticker=AAPL
 
 # 全ティッカー
 make split-all
@@ -349,8 +360,8 @@ vim src/data_split_labeling.yaml
 make generate-experiments
 
 # 3. 特定ティッカーで検証
-make label ticker=TSLA
-make split ticker=TSLA
+make label ticker=AAPL
+make split ticker=AAPL
 
 # 4. 全ティッカーで実行
 make full-pipeline

--- a/src/get_data/fetcher.py
+++ b/src/get_data/fetcher.py
@@ -6,11 +6,18 @@ yfinanceを使用してティッカーの株価データを取得し、Parquet�
     $ python src/get_data/fetcher.py
 """
 
+import sys
 from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
 import yfinance as yf
+
+# UTF-8出力を強制
+if sys.stdout.encoding != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+if sys.stderr.encoding != "utf-8":
+    sys.stderr.reconfigure(encoding="utf-8")
 
 # プロジェクトのルートディレクトリを基準にパスを設定
 # CONFIG_PATH が src/config_universe.yaml に変更


### PR DESCRIPTION
- Add UTF-8 encoding configuration for PowerShell and Python
- Add data/processed directory creation step
- Standardize ticker examples to AAPL throughout README
- Add UTF-8 output configuration in fetcher.py to prevent Japanese text garbling
- Clarify execution order: make up -> fetch -> full-pipeline -> chart

Resolves #17